### PR TITLE
Add css file to bower main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,10 @@
     "Urmil Parikh <urmil@klarsys.com>"
   ],
   "description": "AngularJS directive to use Material Design icons with custom fill color and size.",
-  "main": "angular-material-icons.min.js",
+  "main": [
+      "angular-material-icons.min.js",
+      "angular-material-icons.css"
+  ],
   "keywords": [
     "angular",
     "material",


### PR DESCRIPTION
The css file is required for proper alignment.
Tools such as Wiredep aren't picking up the css file as a dependency.
This is resolved by adding the css to the main file list in bower.json.